### PR TITLE
Update rust edition and fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Samanta Navarro <ferivoz@riseup.net>"]
 description = "Analysis tool for tar archives"
-edition = "2021"
+edition = "2024"
 homepage = "https://github.com/ferivoz/alquitran"
 keywords = ["pax", "tar", "ustar"]
 license = "MIT"

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,10 +1,10 @@
+use crate::header::BLOCK_SIZE;
 use crate::header::Format;
 use crate::header::LintHeader;
-use crate::header::BLOCK_SIZE;
 use crate::issues::Hint;
 use crate::issues::Issue;
-use crate::lint::lint_nul_field;
 use crate::lint::ERROR;
+use crate::lint::lint_nul_field;
 use std::collections::BTreeSet;
 use std::io::Read;
 use std::io::Result;

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,12 +1,12 @@
 use crate::issues::Hint;
 use crate::issues::Issue;
+use crate::lint::ERROR;
+use crate::lint::LintResult;
+use crate::lint::WARNING;
 use crate::lint::lint_nul_field;
 use crate::lint::lint_number_field;
 use crate::lint::lint_path_field;
 use crate::lint::lint_string_field;
-use crate::lint::LintResult;
-use crate::lint::ERROR;
-use crate::lint::WARNING;
 use core::ops::Range;
 use std::collections::BTreeSet;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use alquitran::archive::Archive;
-use alquitran::header::Format;
 use alquitran::header::BLOCK_SIZE;
+use alquitran::header::Format;
 use alquitran::issues::eprint_issues;
 use std::env;
 use std::fs::File;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,8 @@ fn main() -> Result<()> {
     };
     let result = archive.lint()?;
 
-    match &result.dump {
-        Some(d) => {
-            eprint_bytes(&d.bytes, &d.marks, d.offset);
-        }
-        None => {}
+    if let Some(d) = &result.dump {
+        eprint_bytes(&d.bytes, &d.marks, d.offset);
     }
     eprint_issues(&result.issues);
     for path in result.duplicated_paths.iter() {


### PR DESCRIPTION
Update to rust edition 2024 and fix new clippy warnings. Also format code accordingly.